### PR TITLE
Fix issue #327

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -19,10 +19,11 @@ The rendering of a Twig template can be summarized into four key steps:
 
 ## The Lexer
 
-The lexer tokenizes a template source code into a token stream (each token is an instance of `TwingToken`, and the stream is an instance of `TwingTokenStream`). The default lexer recognizes 13 different token types:
+The lexer tokenizes a template source code into a token stream (each token is an instance of `TwingToken`, and the stream is an instance of `TwingTokenStream`). The default lexer recognizes 15 different token types:
 
 * `TwingToken.BLOCK_START_TYPE`, `TwingToken.BLOCK_END_TYPE`: Delimiters for blocks (`{% %}`)
 * `TwingToken.VAR_START_TYPE`, `TwingToken.VAR_END_TYPE`: Delimiters for variables (`{{ }}`)
+* `TwingToken.COMMENT_START_TYPE`, `TwingToken.COMMENT_END_TYPE`: Delimiters for comments (`{# #}`)
 * `TwingToken.TEXT_TYPE`: A text outside an expression;
 * `TwingToken.NAME_TYPE`: A name in an expression;
 * `TwingToken.NUMBER_TYPE`: A number in an expression;

--- a/src/lib/lexer.ts
+++ b/src/lib/lexer.ts
@@ -217,7 +217,8 @@ export class TwingLexer {
 
         switch (position[1]) {
             case this.options.tag_comment[0]:
-                this.moveCoordinates(textContent + position[0]);
+                this.pushToken(TwingToken.COMMENT_START_TYPE);
+                this.moveCoordinates(position[0]);
                 this.lexComment();
                 break;
             case this.options.tag_block[0]:
@@ -410,10 +411,17 @@ export class TwingLexer {
             throw new TwingErrorSyntax('Unclosed comment.', this.lineno, this.source);
         }
 
-        let text = this.code.substr(this.cursor, match.index) + match[0];
+        let text = this.code.substr(this.cursor, match.index);
+
+        this.pushToken(TwingToken.TEXT_TYPE, text);
 
         this.moveCursor(text);
         this.moveCoordinates(text);
+
+        this.pushToken(TwingToken.COMMENT_END_TYPE);
+
+        this.moveCursor(match[0]);
+        this.moveCoordinates(match[0]);
     }
 
     private lexString() {

--- a/src/lib/node.ts
+++ b/src/lib/node.ts
@@ -7,6 +7,7 @@ export enum TwingNodeType {
     BLOCK = 'block',
     BLOCK_REFERENCE = 'block_reference',
     BODY = 'body',
+    COMMENT = 'comment',
     DEPRECATED = 'deprecated',
     DO = 'do',
     EXPRESSION_ARRAY = 'expression_array',

--- a/src/lib/node/comment.ts
+++ b/src/lib/node/comment.ts
@@ -1,0 +1,14 @@
+import {TwingNode, TwingNodeType} from "../node";
+import {TwingCompiler} from "../compiler";
+
+export class TwingNodeComment extends TwingNode {
+    constructor(data: string, lineno: number, columnno: number) {
+        super(new Map(), new Map([['data', data]]), lineno, columnno);
+
+        this.type = TwingNodeType.COMMENT;
+    }
+
+    compile(compiler: TwingCompiler) {
+        // noop
+    }
+}

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -17,6 +17,7 @@ import {TwingNodeMacro} from "./node/macro";
 import {TwingTokenParser} from "./token-parser";
 import {first} from "./helper/first";
 import {push} from "./helper/push";
+import {TwingNodeComment} from "./node/comment";
 
 const ctype_space = require('locutus/php/ctype/ctype_space');
 const mt_rand = require('locutus/php/math/mt_rand');
@@ -245,6 +246,13 @@ export class TwingParser {
                     if (node !== null) {
                         rv.set(i++, node);
                     }
+
+                    break;
+                case TwingToken.COMMENT_START_TYPE:
+                    this.stream.next();
+                    token = this.stream.expect(TwingToken.TEXT_TYPE);
+                    this.stream.expect(TwingToken.COMMENT_END_TYPE);
+                    rv.set(i++, new TwingNodeComment(token.getValue(), token.getLine(), token.getColumn()));
 
                     break;
                 default:

--- a/src/lib/token.ts
+++ b/src/lib/token.ts
@@ -12,6 +12,8 @@ export class TwingToken {
     static PUNCTUATION_TYPE = 9;
     static INTERPOLATION_START_TYPE = 10;
     static INTERPOLATION_END_TYPE = 11;
+    static COMMENT_START_TYPE = 12;
+    static COMMENT_END_TYPE = 13;
     private value: string;
     private type: number;
     private lineno: number;
@@ -75,6 +77,12 @@ export class TwingToken {
             case TwingToken.INTERPOLATION_END_TYPE:
                 name = 'INTERPOLATION_END_TYPE';
                 break;
+            case TwingToken.COMMENT_START_TYPE:
+                name = 'COMMENT_START_TYPE';
+                break;
+            case TwingToken.COMMENT_END_TYPE:
+                name = 'COMMENT_END_TYPE';
+                break;
             default:
                 throw new Error(`Token of type "${type}" does not exist.`);
         }
@@ -117,6 +125,10 @@ export class TwingToken {
                 return 'begin of string interpolation';
             case TwingToken.INTERPOLATION_END_TYPE:
                 return 'end of string interpolation';
+            case TwingToken.COMMENT_START_TYPE:
+                return 'begin of comment statement';
+            case TwingToken.COMMENT_END_TYPE:
+                return 'end of comment statement';
             default:
                 throw new Error(`Token of type "${type}" does not exist.`);
         }

--- a/test/tests/unit/lib/lexer/test.js
+++ b/test/tests/unit/lib/lexer/test.js
@@ -194,43 +194,43 @@ baz
         let lexer = createLexer();
         let stream = lexer.tokenize(new TwingSource(data, 'index'));
 
-        test.test('"foo\\nbar\\n{%"', function(test) {
+        test.test('"foo\\nbar\\n{%"', function (test) {
             testToken(test, stream.expect(TwingToken.TEXT_TYPE), 'foo\nbar\n', 1, 1);
 
             test.end();
         });
 
-        test.test('"\\n" after "line 10 %}"', function(test) {
+        test.test('"\\n" after "line 10 %}"', function (test) {
             testToken(test, stream.expect(TwingToken.TEXT_TYPE), '\n', 10, 14);
 
             test.end();
         });
 
-        test.test('"{{"', function(test) {
+        test.test('"{{"', function (test) {
             testToken(test, stream.expect(TwingToken.VAR_START_TYPE), null, 11, 1);
 
             test.end();
         });
 
-        test.test('"baz"', function(test) {
+        test.test('"baz"', function (test) {
             testToken(test, stream.expect(TwingToken.NAME_TYPE), 'baz', 12, 1);
 
             test.end();
         });
 
-        test.test('"}}"', function(test) {
+        test.test('"}}"', function (test) {
             testToken(test, stream.expect(TwingToken.VAR_END_TYPE), null, 13, 1);
 
             test.end();
         });
 
-        test.test('"\\n"', function(test) {
+        test.test('"\\n"', function (test) {
             testToken(test, stream.expect(TwingToken.TEXT_TYPE), '\n', 13, 3);
 
             test.end();
         });
 
-        test.test('EOF', function(test) {
+        test.test('EOF', function (test) {
             testToken(test, stream.getCurrent(), null, 14, 1, TwingToken.EOF_TYPE);
 
             test.end();
@@ -249,37 +249,37 @@ baz
         let lexer = createLexer();
         let stream = lexer.tokenize(new TwingSource(template, 'index'));
 
-        test.test('"foo\\nbar{%"', function(test) {
+        test.test('"foo\\nbar{%"', function (test) {
             testToken(test, stream.expect(TwingToken.TEXT_TYPE), 'foo\nbar', 1, 1);
 
             test.end();
         });
 
-        test.test('"{{" after "line 10 %}"', function(test) {
+        test.test('"{{" after "line 10 %}"', function (test) {
             testToken(test, stream.expect(TwingToken.VAR_START_TYPE), null, 10, 17);
 
             test.end();
         });
 
-        test.test('"baz"', function(test) {
+        test.test('"baz"', function (test) {
             testToken(test, stream.expect(TwingToken.NAME_TYPE), 'baz', 11, 1);
 
             test.end();
         });
 
-        test.test('"}}"', function(test) {
+        test.test('"}}"', function (test) {
             testToken(test, stream.expect(TwingToken.VAR_END_TYPE), null, 12, 1);
 
             test.end();
         });
 
-        test.test('"\\n"', function(test) {
+        test.test('"\\n"', function (test) {
             testToken(test, stream.expect(TwingToken.TEXT_TYPE), '\n', 12, 3);
 
             test.end();
         });
 
-        test.test('EOF', function(test) {
+        test.test('EOF', function (test) {
             testToken(test, stream.getCurrent(), null, 13, 1, TwingToken.EOF_TYPE);
 
             test.end();
@@ -288,23 +288,8 @@ baz
         test.end();
     });
 
-    test.test('testLongComments', function (test) {
-        let template = '{#' + '*'.repeat(100000) + '#}';
-
-        let lexer = createLexer();
-        let stream = lexer.tokenize(new TwingSource(template, 'index'));
-
-        test.test('EOF', function(test) {
-            testToken(test, stream.getCurrent(), null, 1, 100005, TwingToken.EOF_TYPE);
-
-            test.end();
-        });
-
-        test.end();
-    });
-
     test.test('verbatim', function (test) {
-        test.test('multiple lines', function(test) {
+        test.test('multiple lines', function (test) {
             let template = `{% verbatim %}
     {{ 'bla' }}
 {% endverbatim %}`;
@@ -318,7 +303,7 @@ baz
                 test.end();
             });
 
-            test.test('EOF', function(test) {
+            test.test('EOF', function (test) {
                 testToken(test, stream.getCurrent(), null, 3, 18, TwingToken.EOF_TYPE);
 
                 test.end();
@@ -333,13 +318,13 @@ baz
             let lexer = createLexer();
             let stream = lexer.tokenize(new TwingSource(template, 'index'));
 
-            test.test('"*"', function(test) {
+            test.test('"*"', function (test) {
                 testToken(test, stream.expect(TwingToken.TEXT_TYPE), '*'.repeat(100000), 1, 15);
 
                 test.end();
             });
 
-            test.test('EOF', function(test) {
+            test.test('EOF', function (test) {
                 testToken(test, stream.getCurrent(), null, 1, 100032, TwingToken.EOF_TYPE);
 
                 test.end();
@@ -352,7 +337,7 @@ baz
     });
 
     test.test('var', function (test) {
-        test.test('multiple lines', function(test) {
+        test.test('multiple lines', function (test) {
             let template = `{{
 bla
 }}`;
@@ -378,7 +363,7 @@ bla
                 test.end();
             });
 
-            test.test('EOF', function(test) {
+            test.test('EOF', function (test) {
                 testToken(test, stream.getCurrent(), null, 3, 3, TwingToken.EOF_TYPE);
 
                 test.end();
@@ -424,7 +409,7 @@ bla
     });
 
     test.test('block', function (test) {
-        test.test('multiple lines', function(test) {
+        test.test('multiple lines', function (test) {
             let template = `{%
 bla
 %}`;
@@ -450,7 +435,7 @@ bla
                 test.end();
             });
 
-            test.test('EOF', function(test) {
+            test.test('EOF', function (test) {
                 testToken(test, stream.getCurrent(), null, 3, 3, TwingToken.EOF_TYPE);
 
                 test.end();
@@ -501,25 +486,25 @@ bla
         let lexer = createLexer();
         let stream = lexer.tokenize(new TwingSource(template, 'index'));
 
-        test.test('"{{"', function(test) {
+        test.test('"{{"', function (test) {
             testToken(test, stream.expect(TwingToken.VAR_START_TYPE), null, 1, 1);
 
             test.end();
         });
 
-        test.test('"922337203685477580700"', function(test) {
+        test.test('"922337203685477580700"', function (test) {
             testToken(test, stream.expect(TwingToken.NUMBER_TYPE), '922337203685477580700', 1, 4);
 
             test.end();
         });
 
-        test.test('" }}"', function(test) {
+        test.test('" }}"', function (test) {
             testToken(test, stream.expect(TwingToken.VAR_END_TYPE), null, 1, 25);
 
             test.end();
         });
 
-        test.test('EOF', function(test) {
+        test.test('EOF', function (test) {
             testToken(test, stream.getCurrent(), null, 1, 28, TwingToken.EOF_TYPE);
 
             test.end();
@@ -538,25 +523,25 @@ bla
             let lexer = createLexer();
             let stream = lexer.tokenize(new TwingSource(fixture.template, 'index'));
 
-            test.test('"{{"', function(test) {
+            test.test('"{{"', function (test) {
                 testToken(test, stream.expect(TwingToken.VAR_START_TYPE), null, 1, 1);
 
                 test.end();
             });
 
-            test.test(`"${fixture.name}"`, function(test) {
+            test.test(`"${fixture.name}"`, function (test) {
                 testToken(test, stream.expect(TwingToken.STRING_TYPE), fixture.expected, 1, 4);
 
                 test.end();
             });
 
-            test.test('" }}"', function(test) {
+            test.test('" }}"', function (test) {
                 testToken(test, stream.expect(TwingToken.VAR_END_TYPE), null, 1, 16);
 
                 test.end();
             });
 
-            test.test('EOF', function(test) {
+            test.test('EOF', function (test) {
                 testToken(test, stream.getCurrent(), null, 1, 19, TwingToken.EOF_TYPE);
 
                 test.end();
@@ -572,61 +557,61 @@ bla
         let lexer = createLexer();
         let stream = lexer.tokenize(new TwingSource(template, 'index'));
 
-        test.test('"foo "', function(test) {
+        test.test('"foo "', function (test) {
             testToken(test, stream.expect(TwingToken.TEXT_TYPE), 'foo ', 1, 1);
 
             test.end();
         });
 
-        test.test('"{{"', function(test) {
+        test.test('"{{"', function (test) {
             testToken(test, stream.expect(TwingToken.VAR_START_TYPE), null, 1, 5);
 
             test.end();
         });
 
-        test.test('""bar"', function(test) {
+        test.test('""bar"', function (test) {
             testToken(test, stream.expect(TwingToken.STRING_TYPE), 'bar ', 1, 9);
 
             test.end();
         });
 
-        test.test('" #{"', function(test) {
+        test.test('" #{"', function (test) {
             testToken(test, stream.expect(TwingToken.INTERPOLATION_START_TYPE), null, 1, 13);
 
             test.end();
         });
 
-        test.test('" baz"', function(test) {
+        test.test('" baz"', function (test) {
             testToken(test, stream.expect(TwingToken.NAME_TYPE), 'baz', 1, 16);
 
             test.end();
         });
 
-        test.test('" + "', function(test) {
+        test.test('" + "', function (test) {
             testToken(test, stream.expect(TwingToken.OPERATOR_TYPE), '+', 1, 20);
 
             test.end();
         });
 
-        test.test('"1"', function(test) {
+        test.test('"1"', function (test) {
             testToken(test, stream.expect(TwingToken.NUMBER_TYPE), '1', 1, 22);
 
             test.end();
         });
 
-        test.test('" }"', function(test) {
+        test.test('" }"', function (test) {
             testToken(test, stream.expect(TwingToken.INTERPOLATION_END_TYPE), null, 1, 23);
 
             test.end();
         });
 
-        test.test('" }}"', function(test) {
+        test.test('" }}"', function (test) {
             testToken(test, stream.expect(TwingToken.VAR_END_TYPE), null, 1, 26);
 
             test.end();
         });
 
-        test.test('EOF', function(test) {
+        test.test('EOF', function (test) {
             testToken(test, stream.getCurrent(), null, 1, 29, TwingToken.EOF_TYPE);
 
             test.end();
@@ -641,19 +626,19 @@ bla
         let lexer = createLexer();
         let stream = lexer.tokenize(new TwingSource(template, 'index'));
 
-        test.test('"{{"', function(test) {
+        test.test('"{{"', function (test) {
             testToken(test, stream.expect(TwingToken.VAR_START_TYPE), null, 1, 1);
 
             test.end();
         });
 
-        test.test('""bar \\#{baz+1}""', function(test) {
+        test.test('""bar \\#{baz+1}""', function (test) {
             testToken(test, stream.expect(TwingToken.STRING_TYPE), 'bar #{baz+1}', 1, 4);
 
             test.end();
         });
 
-        test.test('" }}"', function(test) {
+        test.test('" }}"', function (test) {
             testToken(test, stream.expect(TwingToken.VAR_END_TYPE), null, 1, 19);
 
             test.end();
@@ -674,19 +659,19 @@ bla
         let lexer = createLexer();
         let stream = lexer.tokenize(new TwingSource(template, 'index'));
 
-        test.test('"{{"', function(test) {
+        test.test('"{{"', function (test) {
             testToken(test, stream.expect(TwingToken.VAR_START_TYPE), null, 1, 1);
 
             test.end();
         });
 
-        test.test('""bar # baz""', function(test) {
+        test.test('""bar # baz""', function (test) {
             testToken(test, stream.expect(TwingToken.STRING_TYPE), 'bar # baz', 1, 5);
 
             test.end();
         });
 
-        test.test('" }}"', function(test) {
+        test.test('" }}"', function (test) {
             testToken(test, stream.expect(TwingToken.VAR_END_TYPE), null, 1, 15);
 
             test.end();
@@ -719,55 +704,55 @@ bla
         let lexer = createLexer();
         let stream = lexer.tokenize(new TwingSource(template, 'index'));
 
-        test.test('"{{"', function(test) {
+        test.test('"{{"', function (test) {
             testToken(test, stream.expect(TwingToken.VAR_START_TYPE), null, 1, 1);
 
             test.end();
         });
 
-        test.test('""bar "', function(test) {
+        test.test('""bar "', function (test) {
             testToken(test, stream.expect(TwingToken.STRING_TYPE), 'bar ', 1, 5);
 
             test.end();
         });
 
-        test.test('"#{"', function(test) {
+        test.test('"#{"', function (test) {
             testToken(test, stream.expect(TwingToken.INTERPOLATION_START_TYPE), null, 1, 9);
 
             test.end();
         });
 
-        test.test('""foo"', function(test) {
+        test.test('""foo"', function (test) {
             testToken(test, stream.expect(TwingToken.STRING_TYPE), 'foo', 1, 13);
 
             test.end();
         });
 
-        test.test('"#{"', function(test) {
+        test.test('"#{"', function (test) {
             testToken(test, stream.expect(TwingToken.INTERPOLATION_START_TYPE), null, 1, 16);
 
             test.end();
         });
 
-        test.test('"bar"', function(test) {
+        test.test('"bar"', function (test) {
             testToken(test, stream.expect(TwingToken.NAME_TYPE), 'bar', 1, 18);
 
             test.end();
         });
 
-        test.test('"}"', function(test) {
+        test.test('"}"', function (test) {
             testToken(test, stream.expect(TwingToken.INTERPOLATION_END_TYPE), null, 1, 21);
 
             test.end();
         });
 
-        test.test('" }"', function(test) {
+        test.test('" }"', function (test) {
             testToken(test, stream.expect(TwingToken.INTERPOLATION_END_TYPE), null, 1, 23);
 
             test.end();
         });
 
-        test.test('" }}"', function(test) {
+        test.test('" }}"', function (test) {
             testToken(test, stream.expect(TwingToken.VAR_END_TYPE), null, 1, 26);
 
             test.end();
@@ -788,61 +773,61 @@ bla
         let lexer = createLexer();
         let stream = lexer.tokenize(new TwingSource(template, 'index'));
 
-        test.test('"{%"', function(test) {
+        test.test('"{%"', function (test) {
             testToken(test, stream.expect(TwingToken.BLOCK_START_TYPE), null, 1, 1);
 
             test.end();
         });
 
-        test.test('"foo"', function(test) {
+        test.test('"foo"', function (test) {
             testToken(test, stream.expect(TwingToken.NAME_TYPE), 'foo', 1, 4);
 
             test.end();
         });
 
-        test.test('""bar "', function(test) {
+        test.test('""bar "', function (test) {
             testToken(test, stream.expect(TwingToken.STRING_TYPE), 'bar ', 1, 9);
 
             test.end();
         });
 
-        test.test('"#{"', function(test) {
+        test.test('"#{"', function (test) {
             testToken(test, stream.expect(TwingToken.INTERPOLATION_START_TYPE), null, 1, 13);
 
             test.end();
         });
 
-        test.test('"foo"', function(test) {
+        test.test('"foo"', function (test) {
             testToken(test, stream.expect(TwingToken.STRING_TYPE), 'foo', 1, 17);
 
             test.end();
         });
 
-        test.test('"#{"', function(test) {
+        test.test('"#{"', function (test) {
             testToken(test, stream.expect(TwingToken.INTERPOLATION_START_TYPE), null, 1, 20);
 
             test.end();
         });
 
-        test.test('"bar"', function(test) {
+        test.test('"bar"', function (test) {
             testToken(test, stream.expect(TwingToken.NAME_TYPE), 'bar', 1, 22);
 
             test.end();
         });
 
-        test.test('"}"', function(test) {
+        test.test('"}"', function (test) {
             testToken(test, stream.expect(TwingToken.INTERPOLATION_END_TYPE), null, 1, 25);
 
             test.end();
         });
 
-        test.test('" }"', function(test) {
+        test.test('" }"', function (test) {
             testToken(test, stream.expect(TwingToken.INTERPOLATION_END_TYPE), null, 1, 27);
 
             test.end();
         });
 
-        test.test('" %}"', function(test) {
+        test.test('" %}"', function (test) {
             testToken(test, stream.expect(TwingToken.BLOCK_END_TYPE), null, 1, 30);
 
             test.end();
@@ -863,31 +848,31 @@ bla
         let lexer = createLexer();
         let stream = lexer.tokenize(new TwingSource(template, 'index'));
 
-        test.test('"{{"', function(test) {
+        test.test('"{{"', function (test) {
             testToken(test, stream.expect(TwingToken.VAR_START_TYPE), null, 1, 1);
 
             test.end();
         });
 
-        test.test('"1"', function(test) {
+        test.test('"1"', function (test) {
             testToken(test, stream.expect(TwingToken.NUMBER_TYPE), '1', 1, 4);
 
             test.end();
         });
 
-        test.test('"and"', function(test) {
+        test.test('"and"', function (test) {
             testToken(test, stream.expect(TwingToken.OPERATOR_TYPE), 'and', 1, 6);
 
             test.end();
         });
 
-        test.test('"\n0"', function(test) {
+        test.test('"\n0"', function (test) {
             testToken(test, stream.expect(TwingToken.NUMBER_TYPE), '0', 2, 1);
 
             test.end();
         });
 
-        test.test('"}}"', function(test) {
+        test.test('"}}"', function (test) {
             testToken(test, stream.expect(TwingToken.VAR_END_TYPE), null, 2, 2);
 
             test.end();
@@ -934,7 +919,7 @@ bla
         let lexer = createLexer();
         let stream = lexer.tokenize(new TwingSource(template, 'index'));
 
-        test.test('"\\n\\nfoo\\nbar\\noof\\n\\n"', function(test) {
+        test.test('"\\n\\nfoo\\nbar\\noof\\n\\n"', function (test) {
             testToken(test, stream.expect(TwingToken.TEXT_TYPE), '\n\nfoo\nbar\noof\n\n', 1, 1);
 
             test.end();
@@ -1005,6 +990,31 @@ bla
     });
 
     test.test('lexComment', function (test) {
+        let template = '{# foo #}';
+
+        let lexer = createLexer();
+        let stream = lexer.tokenize(new TwingSource(template, 'index'));
+
+        testToken(test, stream.expect(TwingToken.COMMENT_START_TYPE), null, 1, 1);
+        testToken(test, stream.expect(TwingToken.TEXT_TYPE), ' foo ', 1, 3);
+        testToken(test, stream.expect(TwingToken.COMMENT_END_TYPE), null, 1, 8);
+        testToken(test, stream.getCurrent(), null, 1, 10, TwingToken.EOF_TYPE);
+
+        test.test('long comments', function (test) {
+            let value = '*'.repeat(100000);
+            let template = '{#' + value + '#}';
+
+            let lexer = createLexer();
+            let stream = lexer.tokenize(new TwingSource(template, 'index'));
+
+            testToken(test, stream.expect(TwingToken.COMMENT_START_TYPE), null, 1, 1);
+            testToken(test, stream.expect(TwingToken.TEXT_TYPE), value, 1, 3);
+            testToken(test, stream.expect(TwingToken.COMMENT_END_TYPE), null, 1, 100003);
+            testToken(test, stream.getCurrent(), null, 1, 100005, TwingToken.EOF_TYPE);
+
+            test.end();
+        });
+
         test.test('unclosed comment', function (test) {
             let template = '{#';
 

--- a/test/tests/unit/lib/parser/test.js
+++ b/test/tests/unit/lib/parser/test.js
@@ -9,7 +9,8 @@ const {
     TwingNodeSet,
     TwingLoaderArray,
     TwingSource,
-    TwingErrorSyntax
+    TwingErrorSyntax,
+    TwingNodeType
 } = require('../../../../../build/index');
 
 const tap = require('tape');
@@ -313,6 +314,29 @@ tap.test('parser', function (test) {
         Reflect.set(parser, 'macros', new Map([['foo', 'bar']]));
 
         test.true(parser.hasMacro('foo'));
+
+        test.end();
+    });
+
+    test.test('supports comment tokens', function (test) {
+        let twing = new TwingEnvironment(null, {
+            autoescape: false,
+            optimizations: 0
+        });
+
+        let parser = new TwingParser(twing);
+
+        let node = parser.parse(new TwingTokenStream([
+            new TwingToken(TwingToken.COMMENT_START_TYPE, '', 1, 0),
+            new TwingToken(TwingToken.TEXT_TYPE, 'test', 1, 0),
+            new TwingToken(TwingToken.COMMENT_END_TYPE, '', 1, 0),
+            new TwingToken(TwingToken.EOF_TYPE, '', 1, 0),
+        ]));
+
+        let body = node.getNode('body');
+
+        test.same(body.getNode(0).getType(), TwingNodeType.COMMENT);
+        test.same(body.getNode(0).getAttribute('data'), 'test');
 
         test.end();
     });

--- a/test/tests/unit/lib/token/test.js
+++ b/test/tests/unit/lib/token/test.js
@@ -31,6 +31,8 @@ tap.test('token', function (test) {
         test.same(TwingToken.typeToString(TwingToken.TEXT_TYPE, true), 'TEXT_TYPE');
         test.same(TwingToken.typeToString(TwingToken.VAR_END_TYPE, true), 'VAR_END_TYPE');
         test.same(TwingToken.typeToString(TwingToken.VAR_START_TYPE, true), 'VAR_START_TYPE');
+        test.same(TwingToken.typeToString(TwingToken.COMMENT_START_TYPE, true), 'COMMENT_START_TYPE');
+        test.same(TwingToken.typeToString(TwingToken.COMMENT_END_TYPE, true), 'COMMENT_END_TYPE');
 
         test.throws(function() {
             TwingToken.typeToString(-999);
@@ -53,6 +55,8 @@ tap.test('token', function (test) {
         test.same(TwingToken.typeToEnglish(TwingToken.TEXT_TYPE), 'text');
         test.same(TwingToken.typeToEnglish(TwingToken.VAR_END_TYPE), 'end of print statement');
         test.same(TwingToken.typeToEnglish(TwingToken.VAR_START_TYPE), 'begin of print statement');
+        test.same(TwingToken.typeToEnglish(TwingToken.COMMENT_START_TYPE), 'begin of comment statement');
+        test.same(TwingToken.typeToEnglish(TwingToken.COMMENT_END_TYPE), 'end of comment statement');
 
         test.throws(function() {
             TwingToken.typeToEnglish(-999);


### PR DESCRIPTION
Comments are now extracted as "begin" and "end" comment tokens by the lexer. The content
of the comment is extracted as a text token.
A new comment node class (of type TwingNodeType.COMMENT) has been added and is
extracted by the parser into the AST. Its compile method does nothing.