### PR TITLE
Interactive Playground

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build
 coverage
 docs/.bundle
 docs/_site
+docs/assets/twing.min.js
 docs/vendor
 node_modules
 tmp

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -29,6 +29,7 @@
                 <a class="page-link" href="{{ site.baseurl }}{% link api.md %}">Twing for Developers</a>
                 <a class="page-link" href="{{ site.baseurl }}{% link language-reference/index.md %}">Twig Language
                     Reference</a>
+                <a class="page-link" href="{{ site.baseurl }}{% link interactive_playground.md %}">Interactive Playground</a>
             </div>
         </nav>
     </div>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ page.lang | default: site.lang | default: " en" }}">
+<html lang="{{ page.lang | default: site.lang | default: "en" }}">
 
 {% include head.html %}
 

--- a/docs/assets/json-stringify-safe.js
+++ b/docs/assets/json-stringify-safe.js
@@ -1,0 +1,25 @@
+// https://github.com/moll/json-stringify-safe
+
+function stringify(obj, replacer, spaces, cycleReplacer) {
+    return JSON.stringify(obj, serializer(replacer, cycleReplacer), spaces)
+}
+
+function serializer(replacer, cycleReplacer) {
+    var stack = [], keys = [];
+
+    if (cycleReplacer == null) cycleReplacer = function (key, value) {
+        if (stack[0] === value) return "[Circular ~]";
+        return "[Circular ~." + keys.slice(0, stack.indexOf(value)).join(".") + "]"
+    };
+
+    return function (key, value) {
+        if (stack.length > 0) {
+            var thisPos = stack.indexOf(this);
+            ~thisPos ? stack.splice(thisPos + 1) : stack.push(this);
+            ~thisPos ? keys.splice(thisPos, Infinity, key) : keys.push(key);
+            if (~stack.indexOf(value)) value = cycleReplacer.call(this, key, value)
+        } else stack.push(value);
+
+        return replacer == null ? value : replacer.call(this, key, value)
+    }
+}

--- a/docs/assets/playground.css
+++ b/docs/assets/playground.css
@@ -1,0 +1,11 @@
+.playground {
+    display: flex;
+}
+
+.playground .left-col {
+    flex: 1;
+}
+
+.playground .right-col {
+    flex: 1;
+}

--- a/docs/assets/playground.js
+++ b/docs/assets/playground.js
@@ -1,0 +1,97 @@
+class Playground {
+    constructor($el) {
+        this.$el = $el;
+        this.init();
+    }
+
+    init() {
+        this.twing = new Twing.TwingEnvironment();
+        this.initLayout();
+        this.initCodeMirror();
+        this.render();
+    }
+
+    initLayout() {
+        this.$leftCol = document.createElement('div');
+        this.$leftCol.classList.add('left-col');
+
+        this.$rightCol = document.createElement('div');
+        this.$rightCol.classList.add('right-col');
+
+        const $input = document.createElement('div');
+        const $inputTitle = document.createElement('h3');
+        $inputTitle.textContent = 'Input';
+        $input.appendChild($inputTitle);
+        this.$leftCol.appendChild($input);
+
+        this.$tokens = document.createElement('div');
+        const $tokensTitle = document.createElement('h3');
+        $tokensTitle.textContent = 'Tokens';
+        this.$tokens.appendChild($tokensTitle);
+        this.$rightCol.appendChild(this.$tokens);
+
+        this.$ast = document.createElement('div');
+        const $astTitle = document.createElement('h3');
+        $astTitle.textContent = 'Abstract Syntax Tree';
+        this.$ast.appendChild($astTitle);
+        this.$rightCol.appendChild(this.$ast);
+
+        this.$el.appendChild(this.$leftCol);
+        this.$el.appendChild(this.$rightCol);
+    }
+
+    initCodeMirror() {
+        const initialValue = this.$el.dataset.initialValue;
+
+        // Input
+        const $cmInput = document.createElement('div');
+        this.$leftCol.appendChild($cmInput);
+
+        this.cmInput = new CodeMirror($cmInput, {
+            value: initialValue,
+            lineNumbers: true,
+            mode: 'twig',
+        });
+
+        this.cmInput.on('change', this.render.bind(this));
+
+        // Output tokens
+        this.cmOutputTokens = new CodeMirror(this.$tokens, {
+            mode: {name: 'javascript', json: true},
+            readOnly: true,
+            lineNumbers: true,
+            foldGutter: true,
+            gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter'],
+        });
+
+        // Output AST
+        this.cmOutputAST = new CodeMirror(this.$ast, {
+            mode: {name: 'javascript', json: true},
+            readOnly: true,
+            lineNumbers: true,
+            foldGutter: true,
+            gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter'],
+        });
+    }
+
+    render() {
+        const updateCm = function (cm, value) {
+            let info = cm.getScrollInfo();
+            cm.setValue(stringify(value, null, 2));
+            cm.scrollTo(info.left, info.top);
+        };
+
+        try {
+            const source = new Twing.TwingSource(this.cmInput.getValue());
+            const tokens = this.twing.tokenize(source);
+            const ast = this.twing.parse(tokens);
+
+            updateCm(this.cmOutputTokens, tokens);
+            updateCm(this.cmOutputAST, ast);
+        } catch (error) {
+            console.log(error)
+            this.cmOutputTokens.setValue(error.message);
+            this.cmOutputAST.setValue(error.message);
+        }
+    }
+}

--- a/docs/assets/playground.js
+++ b/docs/assets/playground.js
@@ -86,6 +86,10 @@ class Playground {
             const tokens = this.twing.tokenize(source);
             const ast = this.twing.parse(tokens);
 
+            console.clear();
+            console.log('Tokens', tokens);
+            console.log('AST', ast);
+
             updateCm(this.cmOutputTokens, tokens);
             updateCm(this.cmOutputAST, ast);
         } catch (error) {

--- a/docs/interactive_playground.md
+++ b/docs/interactive_playground.md
@@ -1,0 +1,28 @@
+Interactive Playground
+======================
+
+<div class="playground" data-initial-value="{% raw %}{% set world = 'world' %}
+Hello {{ world }}!{% endraw %}"></div>
+
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.44.0/codemirror.min.css" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.44.0/addon/fold/foldgutter.min.css" />
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.44.0/codemirror.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.44.0/mode/twig/twig.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.44.0/mode/javascript/javascript.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.44.0/addon/fold/foldcode.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.44.0/addon/fold/foldgutter.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.44.0/addon/fold/brace-fold.min.js"></script>
+<script src="/twing/assets/twing.min.js"></script>
+<script src="/twing/assets/json-stringify-safe.js"></script>
+<link rel="stylesheet" href="/twing/assets/playground.css">
+<script src="/twing/assets/playground.js"></script>
+<script>
+let playground;
+document.addEventListener('DOMContentLoaded', function() {
+    playground = new Playground(document.querySelector('.playground'));
+}, false);
+</script>
+
+[back][back-url]
+
+[back-url]: {{ site.baseurl }}{% link index.md %}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "postpack": "rimraf lib dist browser.* index.*",
     "test": "npm run fastest:all",
     "test:browser": "npm run fastest:integration:browser",
-    "test:docs": "cd docs && bundle exec jekyll build",
+    "test:docs": "npm run predocs && cd docs && bundle exec jekyll build",
     "test:types": "tsc --project test/tests/types",
     "fastest:all": "tape 'test/tests/**/test.js' | tap-bail | tap-spec",
     "fastest:integration": "tape test/tests/integration/**/test.js | tap-bail | tap-spec",
@@ -45,7 +45,8 @@
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "build": "tsc --project .",
     "bundle": "browserify build/browser.js -g uglifyify -s Twing -o build/dist/lib.min.js",
-    "docs": "cd docs && bundle exec jekyll serve",
+    "predocs": "npm run bundle && cp build/dist/lib.min.js docs/assets/twing.min.js",
+    "docs": "npm run predocs && cd docs && bundle exec jekyll serve",
     "docs:install": "cd docs && bundle install --path vendor/bundle"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "build": "tsc --project .",
     "bundle": "browserify build/browser.js -g uglifyify -s Twing -o build/dist/lib.min.js",
-    "predocs": "npm run bundle && cp build/dist/lib.min.js docs/assets/twing.min.js",
+    "predocs": "npm run build && npm run bundle && cp build/dist/lib.min.js docs/assets/twing.min.js",
     "docs": "npm run predocs && cd docs && bundle exec jekyll serve",
     "docs:install": "cd docs && bundle install --path vendor/bundle"
   },


### PR DESCRIPTION
Something I really miss when developing my Prettier plugin, is that I should put some `console.log` a bit everywhere to know how and what a Twig code will transformed into tokens and AST.

This PR add a new page and tab, allowing the user to write Twig code:
![Capture d'écran de 2019-03-24 14-51-44](https://user-images.githubusercontent.com/2103975/54880418-a2591300-4e44-11e9-97ec-0c6f759217b2.png)

If there is an input error:
![Capture d'écran de 2019-03-24 14-53-09](https://user-images.githubusercontent.com/2103975/54880419-a4bb6d00-4e44-11e9-83b3-5f59ccecc067.png)

Also for the moment, there is a problem for properties that are a `Map` object.
They are not JSON-stringifiable:
![Capture d'écran de 2019-03-24 14-56-18](https://user-images.githubusercontent.com/2103975/54880453-0085f600-4e45-11e9-8a39-8b5421a27202.png)
Refs:
- https://stackoverflow.com/questions/29085197/how-do-you-json-stringify-an-es6-map
- https://macwright.org/2017/03/13/maps-not-strictly-better.html#con-maps-and-json-dont-get-along

I think the method [`serializer`](https://github.com/ericmorand/twing/pull/331/files#diff-e25951b5d828d7340874e75dfbb0d777R7) can be patched.


Some futur improvments:
- It would be nice to have an interactive playground for each new PR, like Prettier does with Netlify:
  - https://github.com/prettier/prettier/pull/5996
  - https://deploy-preview-5996--prettier.netlify.com/playground/
- Execute a debounce method to prevent performance slowness when the user type fast
- Add a way to pre-fill the input textarea (via a query params)
- Add a way to share a pre-filled input
- Sort properties `nodes` and `attributes` and put them at the end, in order to improve readability  