### PR TITLE
Add JS interpolation test case

### DIFF
--- a/test/tests/integration/fixtures/regression/js_interpolation/expected.html
+++ b/test/tests/integration/fixtures/regression/js_interpolation/expected.html
@@ -1,0 +1,1 @@
+${thisShouldBeHandledAsRawText}

--- a/test/tests/integration/fixtures/regression/js_interpolation/index.twig
+++ b/test/tests/integration/fixtures/regression/js_interpolation/index.twig
@@ -1,0 +1,1 @@
+${thisShouldBeHandledAsRawText}

--- a/test/tests/integration/fixtures/regression/js_interpolation/test.js
+++ b/test/tests/integration/fixtures/regression/js_interpolation/test.js
@@ -1,0 +1,19 @@
+const TwingTestIntegrationTestCaseBase = require('../../../../../integration-test-case');
+
+module.exports = class extends TwingTestIntegrationTestCaseBase {
+    getDescription() {
+        return 'Template can contain JS interpolation-like strings';
+    }
+
+    getTemplates() {
+        let templates = super.getTemplates();
+
+        templates.set('index.twig', require('./index.twig'));
+
+        return templates;
+    }
+
+    getExpected() {
+        return require('./expected.html');
+    }
+};


### PR DESCRIPTION
This test is currently failing, as any string containing JS interpolation-like syntax like this:
`${something}`
will return a JS error since it apparently gets rendered in the resulting JS class, as JS code.